### PR TITLE
Feature/add osx vscode compliation support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .vs/
+.vscode/
+*.userprefs

--- a/src/HomeNet/project.json
+++ b/src/HomeNet/project.json
@@ -31,6 +31,7 @@
     "Microsoft.EntityFrameworkCore.Tools": "1.0.0-preview2-final"
   },
   "runtimes": {
-    "win10-x64": {}
+    "win10-x64": {},
+    "osx.10.11-x64": {}
   }
 }


### PR DESCRIPTION
- gitignore .vscode folder
- add "osx.10.11-x64" to runtime list